### PR TITLE
Update README.md to include branch in fisher cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This is a drop-in replacement for all [fish](https://fishshell.com/) packages un
 Install with:
 
 ```
-fisher install mbollmann/fishpkgs
+fisher install mbollmann/fishpkgs@main
 ```


### PR DESCRIPTION
Since GitHub moved to `main` as the default branch instead of `master`, some versions of `fisher` will fail to install the plugin unless the branch is specified directly.

Suggest adding it to the command in the README since it doesn't hurt and fixes that case.